### PR TITLE
Typo

### DIFF
--- a/components/pixi/src/gnoga-gui-plugin-pixi-sprite.adb
+++ b/components/pixi/src/gnoga-gui-plugin-pixi-sprite.adb
@@ -450,9 +450,9 @@ package body Gnoga.Gui.Plugin.Pixi.Sprite is
 
    procedure Anchor
      (Sprite      : in out Sprite_Type;
-      Row, Column : in     Gnoga.Types.Frational_Range_Type)
+      Row, Column : in     Gnoga.Types.Fractional_Range_Type)
    is
-      function Image is new UXStrings.Conversions.Fixed_Point_Image (Gnoga.Types.Frational_Range_Type);
+      function Image is new UXStrings.Conversions.Fixed_Point_Image (Gnoga.Types.Fractional_Range_Type);
    begin
       Gnoga.Server.Connection.Execute_Script
         (Sprite.Connection_ID, "gnoga['" & Sprite.ID & "'].anchor = {x:" & Image (Column) & ",y:" & Image (Row) & "};");
@@ -464,10 +464,10 @@ package body Gnoga.Gui.Plugin.Pixi.Sprite is
 
    function Row_Anchor
      (Sprite : in Sprite_Type)
-      return Gnoga.Types.Frational_Range_Type
+      return Gnoga.Types.Fractional_Range_Type
    is
    begin
-      return Gnoga.Types.Frational_Range_Type (Float'(Sprite.Execute ("anchor.y")));
+      return Gnoga.Types.Fractional_Range_Type (Float'(Sprite.Execute ("anchor.y")));
    end Row_Anchor;
 
    -------------------
@@ -476,10 +476,10 @@ package body Gnoga.Gui.Plugin.Pixi.Sprite is
 
    function Column_Anchor
      (Sprite : in Sprite_Type)
-      return Gnoga.Types.Frational_Range_Type
+      return Gnoga.Types.Fractional_Range_Type
    is
    begin
-      return Gnoga.Types.Frational_Range_Type (Float'(Sprite.Execute ("anchor.x")));
+      return Gnoga.Types.Fractional_Range_Type (Float'(Sprite.Execute ("anchor.x")));
    end Column_Anchor;
 
    ----------------

--- a/components/pixi/src/gnoga-gui-plugin-pixi-sprite.ads
+++ b/components/pixi/src/gnoga-gui-plugin-pixi-sprite.ads
@@ -201,13 +201,13 @@ package Gnoga.Gui.Plugin.Pixi.Sprite is
 
    procedure Anchor
      (Sprite      : in out Sprite_Type;
-      Row, Column : in     Gnoga.Types.Frational_Range_Type);
+      Row, Column : in     Gnoga.Types.Fractional_Range_Type);
    function Row_Anchor
      (Sprite : in Sprite_Type)
-      return Gnoga.Types.Frational_Range_Type;
+      return Gnoga.Types.Fractional_Range_Type;
    function Column_Anchor
      (Sprite : in Sprite_Type)
-      return Gnoga.Types.Frational_Range_Type;
+      return Gnoga.Types.Fractional_Range_Type;
    --  The anchor sets the origin point of the texture.
    --  The default is 0,0 this means the texture's origin is the top left
    --  Setting the anchor to 0.5,0.5 means the texture's origin is centered

--- a/components/pixi/src/gnoga-gui-plugin-pixi-text.adb
+++ b/components/pixi/src/gnoga-gui-plugin-pixi-text.adb
@@ -221,9 +221,9 @@ package body Gnoga.Gui.Plugin.Pixi.Text is
 
    procedure Anchor
      (Text        : in out Text_Type;
-      Row, Column : in     Gnoga.Types.Frational_Range_Type)
+      Row, Column : in     Gnoga.Types.Fractional_Range_Type)
    is
-      function Image is new UXStrings.Conversions.Fixed_Point_Image (Gnoga.Types.Frational_Range_Type);
+      function Image is new UXStrings.Conversions.Fixed_Point_Image (Gnoga.Types.Fractional_Range_Type);
    begin
       Gnoga.Server.Connection.Execute_Script
         (Text.Connection_ID, "gnoga['" & Text.ID & "'].anchor = {x:" & Image (Column) & ",y:" & Image (Row) & "};");
@@ -235,10 +235,10 @@ package body Gnoga.Gui.Plugin.Pixi.Text is
 
    function Row_Anchor
      (Text : in Text_Type)
-      return Gnoga.Types.Frational_Range_Type
+      return Gnoga.Types.Fractional_Range_Type
    is
    begin
-      return Gnoga.Types.Frational_Range_Type (Float'(Text.Execute ("anchor.y")));
+      return Gnoga.Types.Fractional_Range_Type (Float'(Text.Execute ("anchor.y")));
    end Row_Anchor;
 
    -------------------
@@ -247,10 +247,10 @@ package body Gnoga.Gui.Plugin.Pixi.Text is
 
    function Column_Anchor
      (Text : in Text_Type)
-      return Gnoga.Types.Frational_Range_Type
+      return Gnoga.Types.Fractional_Range_Type
    is
    begin
-      return Gnoga.Types.Frational_Range_Type (Float'(Text.Execute ("anchor.x")));
+      return Gnoga.Types.Fractional_Range_Type (Float'(Text.Execute ("anchor.x")));
    end Column_Anchor;
 
    ----------------

--- a/components/pixi/src/gnoga-gui-plugin-pixi-text.ads
+++ b/components/pixi/src/gnoga-gui-plugin-pixi-text.ads
@@ -119,13 +119,13 @@ package Gnoga.Gui.Plugin.Pixi.Text is
 
    procedure Anchor
      (Text        : in out Text_Type;
-      Row, Column : in     Gnoga.Types.Frational_Range_Type);
+      Row, Column : in     Gnoga.Types.Fractional_Range_Type);
    function Row_Anchor
      (Text : in Text_Type)
-      return Gnoga.Types.Frational_Range_Type;
+      return Gnoga.Types.Fractional_Range_Type;
    function Column_Anchor
      (Text : in Text_Type)
-      return Gnoga.Types.Frational_Range_Type;
+      return Gnoga.Types.Fractional_Range_Type;
    --  The anchor sets the origin point of the texture.
    --  The default is 0,0 this means the texture's origin is the top left
    --  Setting the anchor to 0.5,0.5 means the texture's origin is centered

--- a/src/gnoga-gui-element-canvas-context_2d.adb
+++ b/src/gnoga-gui-element-canvas-context_2d.adb
@@ -486,7 +486,7 @@ package body Gnoga.Gui.Element.Canvas.Context_2D is
 
    procedure Add_Color_Stop
      (Gradient : in out Gradient_Type;
-      Position : in     Gnoga.Types.Frational_Range_Type;
+      Position : in     Gnoga.Types.Fractional_Range_Type;
       Color    : in     Gnoga.Types.RGBA_Type)
    is
    begin
@@ -495,17 +495,17 @@ package body Gnoga.Gui.Element.Canvas.Context_2D is
 
    procedure Add_Color_Stop
      (Gradient : in out Gradient_Type;
-      Position : in     Gnoga.Types.Frational_Range_Type;
+      Position : in     Gnoga.Types.Fractional_Range_Type;
       Color    : in     String)
    is
-      function Image is new UXStrings.Conversions.Fixed_Point_Image (Gnoga.Types.Frational_Range_Type);
+      function Image is new UXStrings.Conversions.Fixed_Point_Image (Gnoga.Types.Fractional_Range_Type);
    begin
       Gradient.Execute ("addColorStop (" & Image (Position) & ", '" & Color & "');");
    end Add_Color_Stop;
 
    procedure Add_Color_Stop
      (Gradient : in out Gradient_Type;
-      Position : in     Gnoga.Types.Frational_Range_Type;
+      Position : in     Gnoga.Types.Fractional_Range_Type;
       Color    : in     Gnoga.Types.Colors.Color_Enumeration)
    is
    begin

--- a/src/gnoga-gui-element-canvas-context_2d.ads
+++ b/src/gnoga-gui-element-canvas-context_2d.ads
@@ -261,15 +261,15 @@ package Gnoga.Gui.Element.Canvas.Context_2D is
 
    procedure Add_Color_Stop
      (Gradient : in out Gradient_Type;
-      Position : in     Gnoga.Types.Frational_Range_Type;
+      Position : in     Gnoga.Types.Fractional_Range_Type;
       Color    : in     Gnoga.Types.RGBA_Type);
    procedure Add_Color_Stop
      (Gradient : in out Gradient_Type;
-      Position : in     Gnoga.Types.Frational_Range_Type;
+      Position : in     Gnoga.Types.Fractional_Range_Type;
       Color    : in     String);
    procedure Add_Color_Stop
      (Gradient : in out Gradient_Type;
-      Position : in     Gnoga.Types.Frational_Range_Type;
+      Position : in     Gnoga.Types.Fractional_Range_Type;
       Color    : in     Gnoga.Types.Colors.Color_Enumeration);
    --  Specifies the colors and stop positions in a gradient object
 

--- a/src/gnoga-types.adb
+++ b/src/gnoga-types.adb
@@ -204,7 +204,7 @@ package body Gnoga.Types is
       return RGBA_Type
    is
    begin
-      return (Value.Red, Value.Green, Value.Blue, Frational_Range_Type (Float (Value.Alpha) / 255.0));
+      return (Value.Red, Value.Green, Value.Blue, Fractional_Range_Type (Float (Value.Alpha) / 255.0));
    end To_RGBA;
 
    --------------

--- a/src/gnoga-types.ads
+++ b/src/gnoga-types.ads
@@ -67,10 +67,10 @@ package Gnoga.Types is
    type Connection_Data_Access is access all Connection_Data_Type;
    type Pointer_to_Connection_Data_Class is access all Connection_Data_Type'Class;
 
-   type Frational_Range_Type is delta 0.001 range 0.0 .. 1.0;
-   for Frational_Range_Type'Small use 0.001;
+   type Fractional_Range_Type is delta 0.001 range 0.0 .. 1.0;
+   for Fractional_Range_Type'Small use 0.001;
 
-   subtype Alpha_Type is Frational_Range_Type;
+   subtype Alpha_Type is Fractional_Range_Type;
 
    type Color_Type is range 0 .. 255;
 


### PR DESCRIPTION
Substitution of misspelled "Frational" by "Fractional".