### PR TITLE
added key field to keyboard event

### DIFF
--- a/src/gnoga-gui-base.adb
+++ b/src/gnoga-gui-base.adb
@@ -52,7 +52,7 @@ package body Gnoga.Gui.Base is
    --  to the actual X,Y of the target.
 
    Keyboard_Event_Script : constant String :=
-     "e.keyCode + '|' + e.charCode + '|' + e.altKey + '|' + e.ctrlKey + '|'" & " + e.shiftKey + '|' + e.metaKey + '|'";
+     "e.key + '|' + e.keyCode + '|' + e.charCode + '|' + e.altKey + '|' + e.ctrlKey + '|'" & " + e.shiftKey + '|' + e.metaKey + '|'";
 
    function Parse_Mouse_Event
      (Message       : String;
@@ -193,6 +193,7 @@ package body Gnoga.Gui.Base is
       end Split;
    begin
       Event.Message  := Keyboard_Message;
+      Event.Key      := Split;
       Event.Key_Code := Split;
       Event.Key_Char := Split;
       Event.Alt      := Split;

--- a/src/gnoga-gui-base.adb
+++ b/src/gnoga-gui-base.adb
@@ -52,7 +52,8 @@ package body Gnoga.Gui.Base is
    --  to the actual X,Y of the target.
 
    Keyboard_Event_Script : constant String :=
-     "e.key + '|' + e.keyCode + '|' + e.charCode + '|' + e.altKey + '|' + e.ctrlKey + '|'" & " + e.shiftKey + '|' + e.metaKey + '|'";
+     "e.key + '|' + e.keyCode + '|' + e.charCode + '|' + e.altKey + '|' + e.ctrlKey + '|'" &
+     " + e.shiftKey + '|' + e.metaKey + '|'";
 
    function Parse_Mouse_Event
      (Message       : String;

--- a/src/gnoga-gui-base.ads
+++ b/src/gnoga-gui-base.ads
@@ -367,6 +367,7 @@ package Gnoga.Gui.Base is
 
    type Keyboard_Event_Record is record
       Message  : Keyboard_Message_Type := Unknown;
+      Key      : String;
       Key_Code : Integer;
       Key_Char : Wide_Character;
       Alt      : Boolean               := False;

--- a/test/test.gpr
+++ b/test/test.gpr
@@ -9,7 +9,7 @@ project Test is
                  "popups.adb", "forms.adb", "canvas_test.adb", "sprite_test.adb", "cli.adb",
                  "storage.adb", "media.adb", "bootjs.adb", "ttables.adb", "menu.adb",
                  "jdemo.adb", "svg_demo.adb", "align.adb", "pack.adb", "ding.adb",
-                 "image_data.adb",
+                 "image_data.adb", "test_keyboard.adb",
                  "message_boxes.adb", "tree.adb", "plot_test.adb", "test_modal_dialog.adb",
                  "db_sqlite.adb", "db_active.adb", "pragma_sqlite.adb", "files_ops.adb",
                  "mac_test.adb", "singleton.adb", "demo.adb", "db_mysql.adb");

--- a/test/test_keyboard.adb
+++ b/test/test_keyboard.adb
@@ -1,0 +1,51 @@
+with Gnoga.Application.Singleton;
+with Gnoga.Gui.Window;
+with Gnoga.Gui.View;
+with Gnoga.Gui.Base;  use Gnoga.Gui.Base;
+with UxStrings;
+
+procedure Test_Keyboard is
+   Window : Gnoga.Gui.Window.Window_Type;
+   View   : Gnoga.Gui.View.View_Type;
+
+   use type Gnoga.String;
+
+   function "&"
+      (L, R : Standard.String)
+       return Gnoga.String
+   is (UxStrings.From_Latin_1(L & R));
+
+   procedure On_Key_Down
+     (Object         : in out Base_Type'Class;
+      Keyboard_Event : in     Keyboard_Event_Record)
+   is begin
+      Window.On_Key_Down_Handler(null);
+      View.Put("Key: """ & Keyboard_Event.Key & """");
+      View.Put(", ");
+      View.Put("Key Code: " & Keyboard_Event.Key_Code'Image);
+      View.Put(", ");
+      View.Put("Key Char: " & Keyboard_Event.Key_Char'Image);
+      View.New_Line;
+   end On_Key_Down;
+
+   procedure On_Key_Up
+     (Object         : in out Base_Type'Class;
+      Keyboard_Event : in     Keyboard_Event_Record)
+   is begin
+      Window.On_Key_Down_Handler(On_Key_Down'Unrestricted_Access);
+   end On_Key_Up;
+
+begin
+   Gnoga.Application.Title ("Keyboard Event Test");
+   --     Gnoga.Application.Open_URL;
+   Gnoga.Application.Singleton.Initialize(Window);
+
+   View.Create(Window);
+
+   View.Put_Line("Hello Keyboard Event Test");
+
+   Window.On_Key_Up_Handler(On_Key_Up'Unrestricted_Access);
+   Window.On_Key_Down_Handler(On_Key_Down'Unrestricted_Access);
+
+   Gnoga.Application.Singleton.Message_Loop;
+end Test_Keyboard;

--- a/test/tickets/011/essai11.adb
+++ b/test/tickets/011/essai11.adb
@@ -41,7 +41,7 @@ procedure Essai11 is
    is
       pragma Unreferenced (Object);
    begin
-      Text_View.Put (From_ASCII (Key));
+      Text_View.Put (From_Latin_1 (Key));
    end On_Key_Char_Event;
 
    procedure On_Key_Press_Event
@@ -53,6 +53,8 @@ procedure Essai11 is
    begin
       Gnoga.Log
         (Image (Keyboard_Event.Message) &
+         ',' &
+         Keyboard_Event.Key &
          ',' &
          Image (Keyboard_Event.Key_Code) &
          ',' &


### PR DESCRIPTION
This adds the Key field for Keyboard events and resolves #8

Test code:

```
with Gnoga.Application.Singleton;
with Gnoga.Gui.Window;
with Gnoga.Gui.View;
with Gnoga.Gui.Base;  use Gnoga.Gui.Base;
with UxStrings;

procedure Test_Keyboard is
   Window : Gnoga.Gui.Window.Window_Type;
   View   : Gnoga.Gui.View.View_Type;

   use type Gnoga.String;

   function "&"
      (L, R : Standard.String)
       return Gnoga.String
   is (UxStrings.From_Latin_1(L & R));

   procedure On_Key_Down
     (Object         : in out Base_Type'Class;
      Keyboard_Event : in     Keyboard_Event_Record)
   is begin
      Window.On_Key_Down_Handler(null);
      View.Put("Key: """ & Keyboard_Event.Key & """");
      View.Put(", ");
      View.Put("Key Code: " & Keyboard_Event.Key_Code'Image);
      View.Put(", ");
      View.Put("Key Char: " & Keyboard_Event.Key_Char'Image);
      View.New_Line;
   end On_Key_Down;

   procedure On_Key_Up
     (Object         : in out Base_Type'Class;
      Keyboard_Event : in     Keyboard_Event_Record)
   is begin
      Window.On_Key_Down_Handler(On_Key_Down'Unrestricted_Access);
   end On_Key_Up;

begin
   Gnoga.Application.Title ("Keyboard Event Test");
   Gnoga.Application.Open_URL;
   Gnoga.Application.Singleton.Initialize(Window);

   View.Create(Window);

   View.Put_Line("Hello Keyboard Event Test");

   Window.On_Key_Up_Handler(On_Key_Up'Unrestricted_Access);
   Window.On_Key_Down_Handler(On_Key_Down'Unrestricted_Access);

   Gnoga.Application.Singleton.Message_Loop;
end Test_Keyboard;
```